### PR TITLE
Add ARIA labels to buttons

### DIFF
--- a/app/visit/page.js
+++ b/app/visit/page.js
@@ -25,7 +25,7 @@ export const Visit = () => {
                             <div className={styles.address}>
                                 <p>1597 Arden Nollville Rd.</p>
                                 <p>Inwood, WV 25428</p>
-                                <button className={styles.copy} onClick={copyAddress}>
+                                <button aria-label="Copy address" className={styles.copy} onClick={copyAddress}>
                                     <svg xmlns="http://www.w3.org/2000/svg" height="1.5em" viewBox="0 -960 960 960"><path d="M371.31-230q-41.03 0-69.67-28.64T273-328.31v-463.38q0-41.03 28.64-69.67T371.31-890h343.38q41.03 0 69.67 28.64T813-791.69v463.38q0 41.03-28.64 69.67T714.69-230H371.31Zm0-86h343.38q4.62 0 8.46-3.85 3.85-3.84 3.85-8.46v-463.38q0-4.62-3.85-8.46-3.84-3.85-8.46-3.85H371.31q-4.62 0-8.46 3.85-3.85 3.84-3.85 8.46v463.38q0 4.62 3.85 8.46 3.84 3.85 8.46 3.85Zm-166 252q-41.03 0-69.67-28.64T107-162.31v-549.38h86v549.38q0 4.62 3.85 8.46 3.84 3.85 8.46 3.85h429.38v86H205.31ZM359-316v-488 488Z" /></svg>
                                 </button>
                             </div>

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -42,6 +42,8 @@ export const Navbar = () => {
                     <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e3e3e3"><path d="m600-120-240-84-186 72q-20 8-37-4.5T120-170v-560q0-13 7.5-23t20.5-15l212-72 240 84 186-72q20-8 37 4.5t17 33.5v560q0 13-7.5 23T812-192l-212 72Zm-40-98v-468l-160-56v468l160 56Zm80 0 120-40v-474l-120 46v468Zm-440-10 120-46v-468l-120 40v474Zm440-458v468-468Zm-320-56v468-468Z" /></svg>
                 </Link>
                 <button
+                    aria-label="Toggle menu"
+                    aria-expanded={isOpen}
                     onClick={() => setIsOpen(!isOpen)} className={styles.hamburger + (isOpen ? " " + styles.open : "")}
                 >
                     <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#e8eaed"><path d="M120-240v-80h720v80H120Zm0-200v-80h720v80H120Zm0-200v-80h720v80H120Z" /></svg>


### PR DESCRIPTION
## Summary
- add `aria-label` on the copy address button
- expand the hamburger button accessibility with `aria-label` and `aria-expanded`
