### PR TITLE
QR Code Scanning Analytics

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -3,6 +3,7 @@ import FloatingNav from "./floatingNav"
 import Footer from "./footer"
 import { Analytics } from "@vercel/analytics/next"
 import QrTracker from "./qrTracker"
+import { Suspense } from "react"
 
 const { default: Navbar } = require("./navbar")
 
@@ -12,7 +13,7 @@ const Layout = (props) => {
         <div className="relative">
             <FloatingNav />
             <Navbar />
-            <QrTracker />
+            <Suspense fallback={null}><QrTracker /></Suspense>
             <Analytics />
             <div className="overflow-x-scroll">
                 {props.children}

--- a/components/layout.js
+++ b/components/layout.js
@@ -2,6 +2,7 @@ import AuxiliaryFAQ from "./auxiliaryFAQ"
 import FloatingNav from "./floatingNav"
 import Footer from "./footer"
 import { Analytics } from "@vercel/analytics/next"
+import QrTracker from "./qrTracker"
 
 const { default: Navbar } = require("./navbar")
 
@@ -11,6 +12,7 @@ const Layout = (props) => {
         <div className="relative">
             <FloatingNav />
             <Navbar />
+            <QrTracker />
             <Analytics />
             <div className="overflow-x-scroll">
                 {props.children}

--- a/components/qrTracker.js
+++ b/components/qrTracker.js
@@ -1,0 +1,18 @@
+'use client'
+
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { track } from '@vercel/analytics';
+
+export default function QrTracker() {
+    const searchParams = useSearchParams();
+    const hasTracked = useRef(false);
+
+    useEffect(() => {
+        const source = searchParams?.get('source')
+        if (source == 'qr' && !hasTracked.current) {
+            track('qr_scan');
+            hasTracked.current = true;
+        }
+    }, searchParams)
+}

--- a/components/qrTracker.js
+++ b/components/qrTracker.js
@@ -1,18 +1,20 @@
 'use client'
 
-import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { track } from '@vercel/analytics';
+import { useEffect, useRef } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { track } from '@vercel/analytics'
 
 export default function QrTracker() {
-    const searchParams = useSearchParams();
-    const hasTracked = useRef(false);
+    const searchParams = useSearchParams()
+    const hasTracked = useRef(false)
 
     useEffect(() => {
         const source = searchParams?.get('source')
-        if (source == 'qr' && !hasTracked.current) {
-            track('qr_scan');
-            hasTracked.current = true;
+        if (source === 'qr' && !hasTracked.current) {
+            track('qr_scan', { source })
+            hasTracked.current = true
         }
-    }, searchParams)
+    }, [searchParams])
+
+    return null
 }

--- a/components/qrTracker.js
+++ b/components/qrTracker.js
@@ -1,18 +1,16 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { track } from '@vercel/analytics'
 
 export default function QrTracker() {
     const searchParams = useSearchParams()
-    const hasTracked = useRef(false)
 
     useEffect(() => {
         const source = searchParams?.get('source')
-        if (source === 'qr' && !hasTracked.current) {
-            track('qr_scan', { source })
-            hasTracked.current = true
+        if (source === 'qr') {
+            track('qr_scan')
         }
     }, [searchParams])
 


### PR DESCRIPTION
When a URL has `?source=qr` in the query, the `QrTracker` component will log a Vercel Analytics event: `qr_scan`.

In order to track the pages/routes scanned, click on `qr_scan` in the Analytics dashboard, and scroll up to Pages/Routes.