### PR TITLE
fix: ensure qr scans reach analytics

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -13,8 +13,8 @@ const Layout = (props) => {
         <div className="relative">
             <FloatingNav />
             <Navbar />
-            <Suspense fallback={null}><QrTracker /></Suspense>
             <Analytics />
+            <Suspense fallback={null}><QrTracker /></Suspense>
             <div className="overflow-x-scroll">
                 {props.children}
                 <AuxiliaryFAQ />

--- a/components/qrTracker.js
+++ b/components/qrTracker.js
@@ -1,17 +1,18 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { track } from '@vercel/analytics'
 
 export default function QrTracker() {
     const searchParams = useSearchParams()
     const source = searchParams?.get('source')
+    const hasTracked = useRef(false)
 
     useEffect(() => {
-        if (source !== 'qr' || sessionStorage.getItem('qr-source') === '1') return
+        if (source !== 'qr' || hasTracked.current) return
         track('qr_scan', { source: 'qr' })
-        sessionStorage.setItem('qr-source', '1')
+        hasTracked.current = true
     }, [source])
 
     return null

--- a/components/qrTracker.js
+++ b/components/qrTracker.js
@@ -6,13 +6,13 @@ import { track } from '@vercel/analytics'
 
 export default function QrTracker() {
     const searchParams = useSearchParams()
+    const source = searchParams?.get('source')
 
     useEffect(() => {
-        const source = searchParams?.get('source')
-        if (source === 'qr') {
-            track('qr_scan')
-        }
-    }, [searchParams])
+        if (source !== 'qr' || sessionStorage.getItem('qr-source') === '1') return
+        track('qr_scan', { source: 'qr' })
+        sessionStorage.setItem('qr-source', '1')
+    }, [source])
 
     return null
 }


### PR DESCRIPTION
- Move <Analytics /> ahead of the QR tracker so the Vercel script loads before track is invoked.
- Refine QrTracker to derive the source param once, guard repeat fires with a useRef, and keep emitting qr_scan on every mount.
- Drop the sessionStorage dependency so each QR visit is recorded even after earlier scans.